### PR TITLE
Update config.pp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -230,6 +230,7 @@ class puppet::config {
     path              => "${sysconfigdir}/puppet",
     setting           => 'DAEMON_OPTS',
     subsetting        => '--logdest',
-    value             => $logdest
+    value             => $logdest,
+    subsetting_key_val_separator => '='
   }
 }


### PR DESCRIPTION
Adding subsetting_key_val_separator for logdest in puppet agent config which is injected empty string by default causing restarts to fails due to incorrect setting
original - '--logdest/var/log/puppetlabs/puppet/puppet.log'
proposed change - '--logdest /var/log/puppetlabs/puppet/puppet.log'